### PR TITLE
Add screening subroutines for metadata writes

### DIFF
--- a/ncdiag/nc_diag_write_mod.F90
+++ b/ncdiag/nc_diag_write_mod.F90
@@ -220,7 +220,8 @@ module nc_diag_write_mod
         nc_diag_metadata_allocmulti, &
         nc_diag_metadata_prealloc_vars, &
         nc_diag_metadata_prealloc_vars_storage, &
-        nc_diag_metadata_prealloc_vars_storage_all
+        nc_diag_metadata_prealloc_vars_storage_all, &
+        nc_diag_metadata_to_single
     
     ! Load data2d writing API + auxillary functions for our use
     use ncdw_data2d, only: nc_diag_data2d, &


### PR DESCRIPTION
This creates two subroutines and an interface (`nc_diag_metadata_to_single_`, `nc_diag_metadata_to_single_operator`, and `nc_diag_metadata_to_single`) to screen incoming double variables for `nan`s before converting them to singles.  The second subroutine adds the ability to do basic arithmetic after first checking if both variables are not `nan`.  Fixes #1.