### PR TITLE
Fixed operator length

### DIFF
--- a/ncdiag/ncdw_metadata.F90
+++ b/ncdiag/ncdw_metadata.F90
@@ -1234,7 +1234,7 @@ module ncdw_metadata
             character(len=*), intent(in)           :: metadata_name
             real(r_double), intent(in)             :: metadata_operand_x
             real(r_double), intent(in)             :: metadata_operand_y
-            character(len=2), intent(in)           :: metadata_operator
+            character(len=*), intent(in)           :: metadata_operator
             real(r_single)                         :: f_metadata_value
 
 #ifdef ENABLE_ACTION_MSGS


### PR DESCRIPTION
The operator length has been changed from `2` to `*`, which prevents the extra byte from being written to the input.  This was tested by running the GSI global_3dvar test with Intel 2022.1.2 on Hera, which did not produce any warning messages about invalid operators. Fixes #3 