### PR TITLE
Fix requested chunk cache size when appending

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 
 project(ncdiag
-        VERSION 1.1.1
+        VERSION 1.1.2
         LANGUAGES Fortran)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/ncdiag/nc_diag_write_mod.F90
+++ b/ncdiag/nc_diag_write_mod.F90
@@ -324,7 +324,7 @@ module nc_diag_write_mod
                 if (present(append) .AND. (append .eqv. .TRUE.)) then
                     ! Open the file in append mode!
                     call nclayer_check( nf90_open(filename, NF90_WRITE, ncid, &
-                        bsize, cache_nelems = 16777216) ) ! Optimization settings
+                        bsize, cache_nelems = 16384) ) ! Optimization settings
                     
                     ! Set the append flag
                     append_only = .TRUE.
@@ -341,7 +341,7 @@ module nc_diag_write_mod
                     ! track of what file you're working on. We're returning that
                     ! here.
                     call nclayer_check( nf90_create(filename, OR(NF90_NETCDF4, NF90_CLOBBER), ncid, &
-                        0, bsize, cache_nelems = 16777216) ) ! Optimization settings
+                        0, bsize, cache_nelems = 16384) ) ! Optimization settings
                 end if
                 
                 ! Allocation sanity checks...


### PR DESCRIPTION
The requested HDF5 chunk cache size was set to 16GB when appending to preexistent diagnostic netCDF files.  This resulted in memory allocations > 5GB/PE in some cases, which could overallocate a Hera or Orion compute node and thus caused GSI regression tests to fail.  This was not an issue with HDF5 v1.10.6 (not sure why) , but is with 1.14.0.

The default is 1MB.  I assumed the intent was to set a size of 16MB.  All GSI regression tests now pass their `memthresh` and `maxmem` tests.

Fixes #7