### PR TITLE
set logical based on availability of optional logical argument

### DIFF
--- a/ncdiag/nc_diag_write_mod.F90
+++ b/ncdiag/nc_diag_write_mod.F90
@@ -289,23 +289,23 @@ module nc_diag_write_mod
         !     result in an error with an indication that a bug has
         !     occurred.
         ! 
-        subroutine nc_diag_init(filename, append)
+        subroutine nc_diag_init(filename, append_optional)
             character(len=*),intent(in)    :: filename
-            logical, intent(in), optional  :: append
+            logical, intent(in), optional  :: append_optional
             
-            logical                        :: append_local
+            logical                        :: append
             ! Buffer size variable for NetCDF optimization settings
             ! (Not sure if this helps much...)
             integer                        :: bsize = 16777216;
 
-            append_local = .false.
-            if (present(append)) append_local = append
+            append = .false.
+            if (present(append_optional)) append = append_optional
             
 #ifdef ENABLE_ACTION_MSGS
             character(len=1000)                   :: action_str
             
             if (nclayer_enable_action) then
-                if (present(append)) then
+                if (append) then
                     write(action_str, "(A, L, A)") "nc_diag_init(filename = " // trim(filename) // &
                         ", append = ", append, ")"
                 else
@@ -325,7 +325,7 @@ module nc_diag_write_mod
             if (.NOT. init_done) then
                 ! Special append mode - that means that we need to
                 ! assume that all definitions are set and locked.
-                if (present(append) .AND. (append_local .eqv. .TRUE.)) then
+                if (append .eqv. .TRUE.) then
                     ! Open the file in append mode!
                     call nclayer_check( nf90_open(filename, NF90_WRITE, ncid, &
                         bsize, cache_nelems = 16384) ) ! Optimization settings
@@ -384,7 +384,7 @@ module nc_diag_write_mod
                 ! chaninfo/metadata/data2d to read the NetCDF files,
                 ! build a cache, and set up anything necessary to be
                 ! able to resume writing from before.
-                if (present(append) .AND. (append_local .eqv. .TRUE.)) then
+                if (append .eqv. .TRUE.) then
                     call nclayer_info("Loading chaninfo variables/dimensions from file:")
                     call nc_diag_chaninfo_load_def
                     

--- a/ncdiag/nc_diag_write_mod.F90
+++ b/ncdiag/nc_diag_write_mod.F90
@@ -293,9 +293,13 @@ module nc_diag_write_mod
             character(len=*),intent(in)    :: filename
             logical, intent(in), optional  :: append
             
+            logical                        :: append_local
             ! Buffer size variable for NetCDF optimization settings
             ! (Not sure if this helps much...)
             integer                        :: bsize = 16777216;
+
+            append_local = .false.
+            if (present(append)) append_local = append
             
 #ifdef ENABLE_ACTION_MSGS
             character(len=1000)                   :: action_str
@@ -321,7 +325,7 @@ module nc_diag_write_mod
             if (.NOT. init_done) then
                 ! Special append mode - that means that we need to
                 ! assume that all definitions are set and locked.
-                if (present(append) .AND. (append .eqv. .TRUE.)) then
+                if (present(append) .AND. (append_local .eqv. .TRUE.)) then
                     ! Open the file in append mode!
                     call nclayer_check( nf90_open(filename, NF90_WRITE, ncid, &
                         bsize, cache_nelems = 16384) ) ! Optimization settings
@@ -380,7 +384,7 @@ module nc_diag_write_mod
                 ! chaninfo/metadata/data2d to read the NetCDF files,
                 ! build a cache, and set up anything necessary to be
                 ! able to resume writing from before.
-                if (present(append) .AND. (append .eqv. .TRUE.)) then
+                if (present(append) .AND. (append_local .eqv. .TRUE.)) then
                     call nclayer_info("Loading chaninfo variables/dimensions from file:")
                     call nc_diag_chaninfo_load_def
                     

--- a/ncdiag/nc_diag_write_mod.F90
+++ b/ncdiag/nc_diag_write_mod.F90
@@ -305,9 +305,9 @@ module nc_diag_write_mod
             character(len=1000)                   :: action_str
             
             if (nclayer_enable_action) then
-                if (append_local) then
+                if (present(append)) then
                     write(action_str, "(A, L, A)") "nc_diag_init(filename = " // trim(filename) // &
-                        ", append = ", append_local, ")"
+                        ", append = ", append, ")"
                 else
                     write(action_str, "(A)") "nc_diag_init(filename = " // trim(filename) // &
                         ", append = (not specified))"

--- a/ncdiag/nc_diag_write_mod.F90
+++ b/ncdiag/nc_diag_write_mod.F90
@@ -289,25 +289,25 @@ module nc_diag_write_mod
         !     result in an error with an indication that a bug has
         !     occurred.
         ! 
-        subroutine nc_diag_init(filename, append_optional)
+        subroutine nc_diag_init(filename, append)
             character(len=*),intent(in)    :: filename
-            logical, intent(in), optional  :: append_optional
+            logical, intent(in), optional  :: append
             
-            logical                        :: append
+            logical                        :: append_local
             ! Buffer size variable for NetCDF optimization settings
             ! (Not sure if this helps much...)
             integer                        :: bsize = 16777216;
 
-            append = .false.
-            if (present(append_optional)) append = append_optional
+            append_local = .false.
+            if (present(append)) append_local = append
             
 #ifdef ENABLE_ACTION_MSGS
             character(len=1000)                   :: action_str
             
             if (nclayer_enable_action) then
-                if (append) then
+                if (append_local) then
                     write(action_str, "(A, L, A)") "nc_diag_init(filename = " // trim(filename) // &
-                        ", append = ", append, ")"
+                        ", append = ", append_local, ")"
                 else
                     write(action_str, "(A)") "nc_diag_init(filename = " // trim(filename) // &
                         ", append = (not specified))"
@@ -325,7 +325,7 @@ module nc_diag_write_mod
             if (.NOT. init_done) then
                 ! Special append mode - that means that we need to
                 ! assume that all definitions are set and locked.
-                if (append .eqv. .TRUE.) then
+                if (append_local .eqv. .TRUE.) then
                     ! Open the file in append mode!
                     call nclayer_check( nf90_open(filename, NF90_WRITE, ncid, &
                         bsize, cache_nelems = 16384) ) ! Optimization settings
@@ -384,7 +384,7 @@ module nc_diag_write_mod
                 ! chaninfo/metadata/data2d to read the NetCDF files,
                 ! build a cache, and set up anything necessary to be
                 ! able to resume writing from before.
-                if (append .eqv. .TRUE.) then
+                if (append_local .eqv. .TRUE.) then
                     call nclayer_info("Loading chaninfo variables/dimensions from file:")
                     call nc_diag_chaninfo_load_def
                     

--- a/ncdiag/ncdw_chaninfo.F90
+++ b/ncdiag/ncdw_chaninfo.F90
@@ -1126,8 +1126,6 @@ module ncdw_chaninfo
 #ifdef ENABLE_ACTION_MSGS
             character(len=1000)                   :: action_str
             
-            flush_data_only_local = .false.
-            if (present(flush_data_only) flush_data_only_local = flush_data_only
             if (nclayer_enable_action) then
                 if (present(flush_data_only)) then
                     write(action_str, "(A, L, A)") "nc_diag_chaninfo_write_data(flush_data_only = ", flush_data_only, ")"
@@ -1137,6 +1135,10 @@ module ncdw_chaninfo
                 call nclayer_actionm(trim(action_str))
             end if
 #endif
+
+            flush_data_only_local = .false.
+            if (present(flush_data_only) flush_data_only_local = flush_data_only
+
             ! Check to make sure a file is open / things are loaded!
             if (init_done .AND. allocated(diag_chaninfo_store)) then
                 ! Check to see if we have any variables to write in the

--- a/ncdiag/ncdw_chaninfo.F90
+++ b/ncdiag/ncdw_chaninfo.F90
@@ -1137,7 +1137,7 @@ module ncdw_chaninfo
 #endif
 
             flush_data_only_local = .false.
-            if (present(flush_data_only) flush_data_only_local = flush_data_only
+            if (present(flush_data_only)) flush_data_only_local = flush_data_only
 
             ! Check to make sure a file is open / things are loaded!
             if (init_done .AND. allocated(diag_chaninfo_store)) then

--- a/ncdiag/ncdw_chaninfo.F90
+++ b/ncdiag/ncdw_chaninfo.F90
@@ -1110,6 +1110,8 @@ module ncdw_chaninfo
             ! NOT be locked.
             logical, intent(in), optional         :: flush_data_only
             
+            logical                               :: flush_data_only_local
+            
             integer(i_byte)                       :: data_type
             integer(i_long)                       :: data_type_index
             character(len=100)                    :: data_name
@@ -1124,6 +1126,8 @@ module ncdw_chaninfo
 #ifdef ENABLE_ACTION_MSGS
             character(len=1000)                   :: action_str
             
+            flush_data_only_local = .false.
+            if (present(flush_data_only) flush_data_only_local = flush_data_only
             if (nclayer_enable_action) then
                 if (present(flush_data_only)) then
                     write(action_str, "(A, L, A)") "nc_diag_chaninfo_write_data(flush_data_only = ", flush_data_only, ")"
@@ -1159,7 +1163,7 @@ module ncdw_chaninfo
                                 ! Warn about low data filling... but only if we are finishing
                                 ! our data write (or writing once) - basically, we're NOT in
                                 ! flushing data mode!
-                                if ((.NOT. (present(flush_data_only) .AND. flush_data_only)) .AND. &
+                                if ((.NOT. (present(flush_data_only) .AND. flush_data_only_local)) .AND. &
                                     ((diag_chaninfo_store%var_usage(curdatindex) + &
                                         diag_chaninfo_store%rel_indexes(curdatindex)) < diag_chaninfo_store%nchans)) then
                                     ! NOTE - I0 and TRIM are Fortran 95 specs
@@ -1300,7 +1304,7 @@ module ncdw_chaninfo
                                     
                                     ! Check for data flushing, and if so, update the relative indexes
                                     ! and set var_usage to 0.
-                                    if (present(flush_data_only) .AND. flush_data_only) then
+                                    if (present(flush_data_only) .AND. flush_data_only_local) then
                                         diag_chaninfo_store%rel_indexes(curdatindex) = &
                                             diag_chaninfo_store%rel_indexes(curdatindex) + &
                                             diag_chaninfo_store%var_usage(curdatindex)
@@ -1315,7 +1319,7 @@ module ncdw_chaninfo
                             end do
                             
                             ! If we're flushing data, don't do anything...
-                            if (present(flush_data_only) .AND. flush_data_only) then
+                            if (present(flush_data_only) .AND. flush_data_only_local) then
 #ifdef _DEBUG_MEM_
                                 print *, "In buffer flush mode!"
 #endif

--- a/ncdiag/ncdw_chaninfo.F90
+++ b/ncdiag/ncdw_chaninfo.F90
@@ -1104,13 +1104,13 @@ module ncdw_chaninfo
         !     errors, or even a bug. See the called subroutines'
         !     documentation for details.
         ! 
-        subroutine nc_diag_chaninfo_write_data(flush_data_only_optional)
+        subroutine nc_diag_chaninfo_write_data(flush_data_only)
             ! Optional internal flag to only flush data - if this is
             ! true, data flushing will be performed, and the data will
             ! NOT be locked.
-            logical, intent(in), optional         :: flush_data_only_optional
+            logical, intent(in), optional         :: flush_data_only
             
-            logical                               :: flush_data_only
+            logical                               :: flush_data_only_local
             
             integer(i_byte)                       :: data_type
             integer(i_long)                       :: data_type_index
@@ -1127,13 +1127,13 @@ module ncdw_chaninfo
             character(len=1000)                   :: action_str
 #endif
             
-            flush_data_only = .false.
-            if (present(flush_data_only_optional)) flush_data_only = flush_data_only_optional
+            flush_data_only_local = .false.
+            if (present(flush_data_only)) flush_data_only_local = flush_data_only
             
 #ifdef ENABLE_ACTION_MSGS
             if (nclayer_enable_action) then
-                if (flush_data_only) then
-                    write(action_str, "(A, L, A)") "nc_diag_chaninfo_write_data(flush_data_only = ", flush_data_only, ")"
+                if (flush_data_only_local) then
+                    write(action_str, "(A, L, A)") "nc_diag_chaninfo_write_data(flush_data_only = ", flush_data_only_local, ")"
                 else
                     write(action_str, "(A)") "nc_diag_chaninfo_write_data(flush_data_only = (not specified))"
                 end if
@@ -1167,7 +1167,7 @@ module ncdw_chaninfo
                                 ! Warn about low data filling... but only if we are finishing
                                 ! our data write (or writing once) - basically, we're NOT in
                                 ! flushing data mode!
-                                if ((.NOT. flush_data_only) .AND. &
+                                if ((.NOT. flush_data_only_local) .AND. &
                                     ((diag_chaninfo_store%var_usage(curdatindex) + &
                                         diag_chaninfo_store%rel_indexes(curdatindex)) < diag_chaninfo_store%nchans)) then
                                     ! NOTE - I0 and TRIM are Fortran 95 specs
@@ -1308,7 +1308,7 @@ module ncdw_chaninfo
                                     
                                     ! Check for data flushing, and if so, update the relative indexes
                                     ! and set var_usage to 0.
-                                    if (flush_data_only) then
+                                    if (flush_data_only_local) then
                                         diag_chaninfo_store%rel_indexes(curdatindex) = &
                                             diag_chaninfo_store%rel_indexes(curdatindex) + &
                                             diag_chaninfo_store%var_usage(curdatindex)
@@ -1323,7 +1323,7 @@ module ncdw_chaninfo
                             end do
                             
                             ! If we're flushing data, don't do anything...
-                            if (flush_data_only) then
+                            if (flush_data_only_local) then
 #ifdef _DEBUG_MEM_
                                 print *, "In buffer flush mode!"
 #endif

--- a/ncdiag/ncdw_chaninfo.F90
+++ b/ncdiag/ncdw_chaninfo.F90
@@ -1132,8 +1132,8 @@ module ncdw_chaninfo
             
 #ifdef ENABLE_ACTION_MSGS
             if (nclayer_enable_action) then
-                if (flush_data_only_local) then
-                    write(action_str, "(A, L, A)") "nc_diag_chaninfo_write_data(flush_data_only = ", flush_data_only_local, ")"
+                if (present(flush_data_only)) then
+                    write(action_str, "(A, L, A)") "nc_diag_chaninfo_write_data(flush_data_only = ", flush_data_only, ")"
                 else
                     write(action_str, "(A)") "nc_diag_chaninfo_write_data(flush_data_only = (not specified))"
                 end if

--- a/ncdiag/ncdw_chaninfo.F90
+++ b/ncdiag/ncdw_chaninfo.F90
@@ -1104,13 +1104,13 @@ module ncdw_chaninfo
         !     errors, or even a bug. See the called subroutines'
         !     documentation for details.
         ! 
-        subroutine nc_diag_chaninfo_write_data(flush_data_only)
+        subroutine nc_diag_chaninfo_write_data(flush_data_only_optional)
             ! Optional internal flag to only flush data - if this is
             ! true, data flushing will be performed, and the data will
             ! NOT be locked.
-            logical, intent(in), optional         :: flush_data_only
+            logical, intent(in), optional         :: flush_data_only_optional
             
-            logical                               :: flush_data_only_local
+            logical                               :: flush_data_only
             
             integer(i_byte)                       :: data_type
             integer(i_long)                       :: data_type_index
@@ -1125,9 +1125,14 @@ module ncdw_chaninfo
             
 #ifdef ENABLE_ACTION_MSGS
             character(len=1000)                   :: action_str
+#endif
             
+            flush_data_only = .false.
+            if (present(flush_data_only_optional)) flush_data_only = flush_data_only_optional
+            
+#ifdef ENABLE_ACTION_MSGS
             if (nclayer_enable_action) then
-                if (present(flush_data_only)) then
+                if (flush_data_only) then
                     write(action_str, "(A, L, A)") "nc_diag_chaninfo_write_data(flush_data_only = ", flush_data_only, ")"
                 else
                     write(action_str, "(A)") "nc_diag_chaninfo_write_data(flush_data_only = (not specified))"
@@ -1135,9 +1140,6 @@ module ncdw_chaninfo
                 call nclayer_actionm(trim(action_str))
             end if
 #endif
-
-            flush_data_only_local = .false.
-            if (present(flush_data_only)) flush_data_only_local = flush_data_only
 
             ! Check to make sure a file is open / things are loaded!
             if (init_done .AND. allocated(diag_chaninfo_store)) then
@@ -1165,7 +1167,7 @@ module ncdw_chaninfo
                                 ! Warn about low data filling... but only if we are finishing
                                 ! our data write (or writing once) - basically, we're NOT in
                                 ! flushing data mode!
-                                if ((.NOT. (present(flush_data_only) .AND. flush_data_only_local)) .AND. &
+                                if ((.NOT. (flush_data_only) .AND. &
                                     ((diag_chaninfo_store%var_usage(curdatindex) + &
                                         diag_chaninfo_store%rel_indexes(curdatindex)) < diag_chaninfo_store%nchans)) then
                                     ! NOTE - I0 and TRIM are Fortran 95 specs
@@ -1306,7 +1308,7 @@ module ncdw_chaninfo
                                     
                                     ! Check for data flushing, and if so, update the relative indexes
                                     ! and set var_usage to 0.
-                                    if (present(flush_data_only) .AND. flush_data_only_local) then
+                                    if (flush_data_only) then
                                         diag_chaninfo_store%rel_indexes(curdatindex) = &
                                             diag_chaninfo_store%rel_indexes(curdatindex) + &
                                             diag_chaninfo_store%var_usage(curdatindex)
@@ -1321,7 +1323,7 @@ module ncdw_chaninfo
                             end do
                             
                             ! If we're flushing data, don't do anything...
-                            if (present(flush_data_only) .AND. flush_data_only_local) then
+                            if (flush_data_only) then
 #ifdef _DEBUG_MEM_
                                 print *, "In buffer flush mode!"
 #endif

--- a/ncdiag/ncdw_chaninfo.F90
+++ b/ncdiag/ncdw_chaninfo.F90
@@ -1167,7 +1167,7 @@ module ncdw_chaninfo
                                 ! Warn about low data filling... but only if we are finishing
                                 ! our data write (or writing once) - basically, we're NOT in
                                 ! flushing data mode!
-                                if ((.NOT. (flush_data_only) .AND. &
+                                if ((.NOT. flush_data_only) .AND. &
                                     ((diag_chaninfo_store%var_usage(curdatindex) + &
                                         diag_chaninfo_store%rel_indexes(curdatindex)) < diag_chaninfo_store%nchans)) then
                                     ! NOTE - I0 and TRIM are Fortran 95 specs

--- a/ncdiag/ncdw_data2d.F90
+++ b/ncdiag/ncdw_data2d.F90
@@ -616,8 +616,8 @@ module ncdw_data2d
 
 #ifdef ENABLE_ACTION_MSGS            
             if (nclayer_enable_action) then
-                if (flush_data_only_local) then
-                    write(action_str, "(A, L, A)") "nc_diag_data2d_write_data(flush_data_only = ", flush_data_only_local, ")"
+                if (present(flush_data_only)) then
+                    write(action_str, "(A, L, A)") "nc_diag_data2d_write_data(flush_data_only = ", flush_data_only, ")"
                 else
                     write(action_str, "(A)") "nc_diag_data2d_write_data(flush_data_only = (not specified))"
                 end if

--- a/ncdiag/ncdw_data2d.F90
+++ b/ncdiag/ncdw_data2d.F90
@@ -618,7 +618,7 @@ module ncdw_data2d
 #endif
 
             flush_data_only_local = .false.
-            if (present(flush_data_only_local)) then
+            if (present(flush_data_only)) then
                flush_data_only_local = flush_data_only
             endif
 

--- a/ncdiag/ncdw_data2d.F90
+++ b/ncdiag/ncdw_data2d.F90
@@ -607,11 +607,6 @@ module ncdw_data2d
 #ifdef ENABLE_ACTION_MSGS
             character(len=1000)                   :: action_str
 
-            flush_data_only_local = .false.
-            if (present(flush_data_only_local)) then
-               flush_data_only_local = flush_data_only
-            endif
-            
             if (nclayer_enable_action) then
                 if (present(flush_data_only)) then
                     write(action_str, "(A, L, A)") "nc_diag_data2d_write_data(flush_data_only = ", flush_data_only, ")"
@@ -621,7 +616,12 @@ module ncdw_data2d
                 call nclayer_actionm(trim(action_str))
             end if
 #endif
-            
+
+            flush_data_only_local = .false.
+            if (present(flush_data_only_local)) then
+               flush_data_only_local = flush_data_only
+            endif
+
             ! Initialization MUST occur here, not in decl...
             ! Otherwise, it'll initialize once, and never again...
             ! 

--- a/ncdiag/ncdw_data2d.F90
+++ b/ncdiag/ncdw_data2d.F90
@@ -570,13 +570,13 @@ module ncdw_data2d
             end if
         end subroutine nc_diag_data2d_write_def
         
-        subroutine nc_diag_data2d_write_data(flush_data_only_optional)
+        subroutine nc_diag_data2d_write_data(flush_data_only)
             ! Optional internal flag to only flush data - if this is
             ! true, data flushing will be performed, and the data will
             ! NOT be locked.
-            logical, intent(in), optional         :: flush_data_only_optional
+            logical, intent(in), optional         :: flush_data_only
             
-            logical                               :: flush_data_only
+            logical                               :: flush_data_only_local
             integer(i_byte)                       :: data_type
             character(len=100)                    :: data2d_name
             
@@ -608,16 +608,16 @@ module ncdw_data2d
             character(len=1000)                   :: action_str
 #endif
 
-            flush_data_only = .false.
-            if (present(flush_data_only_optional)) then
-               flush_data_only = flush_data_only_optional
+            flush_data_only_local = .false.
+            if (present(flush_data_only)) then
+               flush_data_only_local = flush_data_only
             endif
 
 
 #ifdef ENABLE_ACTION_MSGS            
             if (nclayer_enable_action) then
-                if (present(flush_data_only)) then
-                    write(action_str, "(A, L, A)") "nc_diag_data2d_write_data(flush_data_only = ", flush_data_only, ")"
+                if (flush_data_only_local) then
+                    write(action_str, "(A, L, A)") "nc_diag_data2d_write_data(flush_data_only = ", flush_data_only_local, ")"
                 else
                     write(action_str, "(A)") "nc_diag_data2d_write_data(flush_data_only = (not specified))"
                 end if
@@ -647,7 +647,7 @@ module ncdw_data2d
                         call nclayer_info("data2d: writing " // trim(data2d_name))
                         
                         ! Warn about data inconsistencies
-                        if (.NOT. (flush_data_only)) then
+                        if (.NOT. (flush_data_only_local)) then
                             current_length_count = diag_data2d_store%stor_i_arr(curdatindex)%icount + &
                                 diag_data2d_store%rel_indexes(curdatindex)
                             
@@ -1008,7 +1008,7 @@ module ncdw_data2d
                             
                             ! Check for data flushing, and if so, update the relative indexes
                             ! and set icount to 0.
-                            if (flush_data_only) then
+                            if (flush_data_only_local) then
                                 diag_data2d_store%rel_indexes(curdatindex) = &
                                     diag_data2d_store%rel_indexes(curdatindex) + &
                                     diag_data2d_store%stor_i_arr(curdatindex)%icount
@@ -1023,7 +1023,7 @@ module ncdw_data2d
                         end if
                     end do
                     
-                    if (flush_data_only) then
+                    if (flush_data_only_local) then
 #ifdef _DEBUG_MEM_
                         print *, "In buffer flush mode!"
 #endif

--- a/ncdiag/ncdw_data2d.F90
+++ b/ncdiag/ncdw_data2d.F90
@@ -576,6 +576,7 @@ module ncdw_data2d
             ! NOT be locked.
             logical, intent(in), optional         :: flush_data_only
             
+            logical                               :: flush_data_only_local
             integer(i_byte)                       :: data_type
             character(len=100)                    :: data2d_name
             
@@ -605,6 +606,11 @@ module ncdw_data2d
             
 #ifdef ENABLE_ACTION_MSGS
             character(len=1000)                   :: action_str
+
+            flush_data_only_local = .false.
+            if (present(flush_data_only_local)) then
+               flush_data_only_local = flush_data_only
+            endif
             
             if (nclayer_enable_action) then
                 if (present(flush_data_only)) then
@@ -638,7 +644,7 @@ module ncdw_data2d
                         call nclayer_info("data2d: writing " // trim(data2d_name))
                         
                         ! Warn about data inconsistencies
-                        if (.NOT. (present(flush_data_only) .AND. flush_data_only)) then
+                        if (.NOT. (present(flush_data_only) .AND. flush_data_only_local)) then
                             current_length_count = diag_data2d_store%stor_i_arr(curdatindex)%icount + &
                                 diag_data2d_store%rel_indexes(curdatindex)
                             
@@ -999,7 +1005,7 @@ module ncdw_data2d
                             
                             ! Check for data flushing, and if so, update the relative indexes
                             ! and set icount to 0.
-                            if (present(flush_data_only) .AND. flush_data_only) then
+                            if (present(flush_data_only) .AND. flush_data_only_local) then
                                 diag_data2d_store%rel_indexes(curdatindex) = &
                                     diag_data2d_store%rel_indexes(curdatindex) + &
                                     diag_data2d_store%stor_i_arr(curdatindex)%icount
@@ -1014,7 +1020,7 @@ module ncdw_data2d
                         end if
                     end do
                     
-                    if (present(flush_data_only) .AND. flush_data_only) then
+                    if (present(flush_data_only) .AND. flush_data_only_local) then
 #ifdef _DEBUG_MEM_
                         print *, "In buffer flush mode!"
 #endif

--- a/ncdiag/ncdw_data2d.F90
+++ b/ncdiag/ncdw_data2d.F90
@@ -570,13 +570,13 @@ module ncdw_data2d
             end if
         end subroutine nc_diag_data2d_write_def
         
-        subroutine nc_diag_data2d_write_data(flush_data_only)
+        subroutine nc_diag_data2d_write_data(flush_data_only_optional)
             ! Optional internal flag to only flush data - if this is
             ! true, data flushing will be performed, and the data will
             ! NOT be locked.
-            logical, intent(in), optional         :: flush_data_only
+            logical, intent(in), optional         :: flush_data_only_optional
             
-            logical                               :: flush_data_only_local
+            logical                               :: flush_data_only
             integer(i_byte)                       :: data_type
             character(len=100)                    :: data2d_name
             
@@ -606,7 +606,15 @@ module ncdw_data2d
             
 #ifdef ENABLE_ACTION_MSGS
             character(len=1000)                   :: action_str
+#endif
 
+            flush_data_only = .false.
+            if (present(flush_data_only_optional)) then
+               flush_data_only = flush_data_only_optional
+            endif
+
+
+#ifdef ENABLE_ACTION_MSGS            
             if (nclayer_enable_action) then
                 if (present(flush_data_only)) then
                     write(action_str, "(A, L, A)") "nc_diag_data2d_write_data(flush_data_only = ", flush_data_only, ")"
@@ -616,11 +624,6 @@ module ncdw_data2d
                 call nclayer_actionm(trim(action_str))
             end if
 #endif
-
-            flush_data_only_local = .false.
-            if (present(flush_data_only)) then
-               flush_data_only_local = flush_data_only
-            endif
 
             ! Initialization MUST occur here, not in decl...
             ! Otherwise, it'll initialize once, and never again...
@@ -644,7 +647,7 @@ module ncdw_data2d
                         call nclayer_info("data2d: writing " // trim(data2d_name))
                         
                         ! Warn about data inconsistencies
-                        if (.NOT. (present(flush_data_only) .AND. flush_data_only_local)) then
+                        if (.NOT. (flush_data_only)) then
                             current_length_count = diag_data2d_store%stor_i_arr(curdatindex)%icount + &
                                 diag_data2d_store%rel_indexes(curdatindex)
                             
@@ -1005,7 +1008,7 @@ module ncdw_data2d
                             
                             ! Check for data flushing, and if so, update the relative indexes
                             ! and set icount to 0.
-                            if (present(flush_data_only) .AND. flush_data_only_local) then
+                            if (flush_data_only) then
                                 diag_data2d_store%rel_indexes(curdatindex) = &
                                     diag_data2d_store%rel_indexes(curdatindex) + &
                                     diag_data2d_store%stor_i_arr(curdatindex)%icount
@@ -1020,7 +1023,7 @@ module ncdw_data2d
                         end if
                     end do
                     
-                    if (present(flush_data_only) .AND. flush_data_only_local) then
+                    if (flush_data_only) then
 #ifdef _DEBUG_MEM_
                         print *, "In buffer flush mode!"
 #endif

--- a/ncdiag/ncdw_metadata.F90
+++ b/ncdiag/ncdw_metadata.F90
@@ -444,13 +444,13 @@ module ncdw_metadata
             end if
         end subroutine nc_diag_metadata_write_def
         
-        subroutine nc_diag_metadata_write_data(flush_data_only)
+        subroutine nc_diag_metadata_write_data(flush_data_only_optional)
             ! Optional internal flag to only flush data - if this is
             ! true, data flushing will be performed, and the data will
             ! NOT be locked.
-            logical, intent(in), optional         :: flush_data_only
+            logical, intent(in), optional         :: flush_data_only_optional
             
-            logical                               :: flush_data_only_local
+            logical                               :: flush_data_only
             
             integer(i_byte)                       :: data_type
             character(len=100)                    :: data_name
@@ -473,9 +473,16 @@ module ncdw_metadata
             
 #ifdef ENABLE_ACTION_MSGS
             character(len=1000)                   :: action_str
+#endif
 
+            flush_data_only = .false.
+            if (present(flush_data_only_optional)) then
+               flush_data_only = flush_data_only_optional
+            endif
+            
+#ifdef ENABLE_ACTION_MSGS            
             if (nclayer_enable_action) then
-                if (present(flush_data_only)) then
+                if (flush_data_only) then
                     write(action_str, "(A, L, A)") "nc_diag_metadata_write_data(flush_data_only = ", flush_data_only, ")"
                 else
                     write(action_str, "(A)") "nc_diag_metadata_write_data(flush_data_only = (not specified))"
@@ -483,11 +490,6 @@ module ncdw_metadata
                 call nclayer_actionm(trim(action_str))
             end if
 #endif
-
-            flush_data_only_local = .false.
-            if (present(flush_data_only)) then
-               flush_data_only_local = flush_data_only
-            endif
 
             ! Initialization MUST occur here, not in decl...
             ! Otherwise, it'll initialize once, and never again...
@@ -510,7 +512,7 @@ module ncdw_metadata
                         call nclayer_info("metadata: writing " // trim(data_name))
                         
                         ! Warn about data inconsistencies
-                        if (.NOT. (present(flush_data_only) .AND. flush_data_only_local)) then
+                        if (.NOT. (flush_data_only)) then
                             current_length_count = diag_metadata_store%stor_i_arr(curdatindex)%icount + &
                                 diag_metadata_store%rel_indexes(curdatindex)
                             
@@ -632,7 +634,7 @@ module ncdw_metadata
                             
                             ! Check for data flushing, and if so, update the relative indexes
                             ! and set icount to 0.
-                            if (present(flush_data_only) .AND. flush_data_only_local) then
+                            if (flush_data_only) then
                                 diag_metadata_store%rel_indexes(curdatindex) = &
                                     diag_metadata_store%rel_indexes(curdatindex) + &
                                     diag_metadata_store%stor_i_arr(curdatindex)%icount
@@ -647,7 +649,7 @@ module ncdw_metadata
                         end if
                     end do
                     
-                    if (present(flush_data_only) .AND. flush_data_only_local) then
+                    if (flush_data_only) then
 #ifdef _DEBUG_MEM_
                         print *, "In buffer flush mode!"
 #endif

--- a/ncdiag/ncdw_metadata.F90
+++ b/ncdiag/ncdw_metadata.F90
@@ -450,6 +450,8 @@ module ncdw_metadata
             ! NOT be locked.
             logical, intent(in), optional         :: flush_data_only
             
+            logical                               :: flush_data_only_local
+            
             integer(i_byte)                       :: data_type
             character(len=100)                    :: data_name
             
@@ -471,6 +473,11 @@ module ncdw_metadata
             
 #ifdef ENABLE_ACTION_MSGS
             character(len=1000)                   :: action_str
+
+            flush_data_only_local = .false.
+            if (present(flush_data_only)) then
+               flush_data_only_local = flush_data_only
+            endif
             
             if (nclayer_enable_action) then
                 if (present(flush_data_only)) then
@@ -502,7 +509,7 @@ module ncdw_metadata
                         call nclayer_info("metadata: writing " // trim(data_name))
                         
                         ! Warn about data inconsistencies
-                        if (.NOT. (present(flush_data_only) .AND. flush_data_only)) then
+                        if (.NOT. (present(flush_data_only) .AND. flush_data_only_local)) then
                             current_length_count = diag_metadata_store%stor_i_arr(curdatindex)%icount + &
                                 diag_metadata_store%rel_indexes(curdatindex)
                             
@@ -624,7 +631,7 @@ module ncdw_metadata
                             
                             ! Check for data flushing, and if so, update the relative indexes
                             ! and set icount to 0.
-                            if (present(flush_data_only) .AND. flush_data_only) then
+                            if (present(flush_data_only) .AND. flush_data_only_local) then
                                 diag_metadata_store%rel_indexes(curdatindex) = &
                                     diag_metadata_store%rel_indexes(curdatindex) + &
                                     diag_metadata_store%stor_i_arr(curdatindex)%icount
@@ -639,7 +646,7 @@ module ncdw_metadata
                         end if
                     end do
                     
-                    if (present(flush_data_only) .AND. flush_data_only) then
+                    if (present(flush_data_only) .AND. flush_data_only_local) then
 #ifdef _DEBUG_MEM_
                         print *, "In buffer flush mode!"
 #endif

--- a/ncdiag/ncdw_metadata.F90
+++ b/ncdiag/ncdw_metadata.F90
@@ -474,11 +474,6 @@ module ncdw_metadata
 #ifdef ENABLE_ACTION_MSGS
             character(len=1000)                   :: action_str
 
-            flush_data_only_local = .false.
-            if (present(flush_data_only)) then
-               flush_data_only_local = flush_data_only
-            endif
-            
             if (nclayer_enable_action) then
                 if (present(flush_data_only)) then
                     write(action_str, "(A, L, A)") "nc_diag_metadata_write_data(flush_data_only = ", flush_data_only, ")"
@@ -488,6 +483,12 @@ module ncdw_metadata
                 call nclayer_actionm(trim(action_str))
             end if
 #endif
+
+            flush_data_only_local = .false.
+            if (present(flush_data_only)) then
+               flush_data_only_local = flush_data_only
+            endif
+
             ! Initialization MUST occur here, not in decl...
             ! Otherwise, it'll initialize once, and never again...
             ! 

--- a/ncdiag/ncdw_metadata.F90
+++ b/ncdiag/ncdw_metadata.F90
@@ -444,13 +444,13 @@ module ncdw_metadata
             end if
         end subroutine nc_diag_metadata_write_def
         
-        subroutine nc_diag_metadata_write_data(flush_data_only_optional)
+        subroutine nc_diag_metadata_write_data(flush_data_only)
             ! Optional internal flag to only flush data - if this is
             ! true, data flushing will be performed, and the data will
             ! NOT be locked.
-            logical, intent(in), optional         :: flush_data_only_optional
+            logical, intent(in), optional         :: flush_data_only
             
-            logical                               :: flush_data_only
+            logical                               :: flush_data_only_local
             
             integer(i_byte)                       :: data_type
             character(len=100)                    :: data_name
@@ -475,15 +475,15 @@ module ncdw_metadata
             character(len=1000)                   :: action_str
 #endif
 
-            flush_data_only = .false.
-            if (present(flush_data_only_optional)) then
-               flush_data_only = flush_data_only_optional
+            flush_data_only_local = .false.
+            if (present(flush_data_only)) then
+               flush_data_only_local = flush_data_only
             endif
             
 #ifdef ENABLE_ACTION_MSGS            
             if (nclayer_enable_action) then
-                if (flush_data_only) then
-                    write(action_str, "(A, L, A)") "nc_diag_metadata_write_data(flush_data_only = ", flush_data_only, ")"
+                if (flush_data_only_local) then
+                    write(action_str, "(A, L, A)") "nc_diag_metadata_write_data(flush_data_only = ", flush_data_only_local, ")"
                 else
                     write(action_str, "(A)") "nc_diag_metadata_write_data(flush_data_only = (not specified))"
                 end if
@@ -512,7 +512,7 @@ module ncdw_metadata
                         call nclayer_info("metadata: writing " // trim(data_name))
                         
                         ! Warn about data inconsistencies
-                        if (.NOT. (flush_data_only)) then
+                        if (.NOT. (flush_data_only_local)) then
                             current_length_count = diag_metadata_store%stor_i_arr(curdatindex)%icount + &
                                 diag_metadata_store%rel_indexes(curdatindex)
                             
@@ -634,7 +634,7 @@ module ncdw_metadata
                             
                             ! Check for data flushing, and if so, update the relative indexes
                             ! and set icount to 0.
-                            if (flush_data_only) then
+                            if (flush_data_only_local) then
                                 diag_metadata_store%rel_indexes(curdatindex) = &
                                     diag_metadata_store%rel_indexes(curdatindex) + &
                                     diag_metadata_store%stor_i_arr(curdatindex)%icount
@@ -649,7 +649,7 @@ module ncdw_metadata
                         end if
                     end do
                     
-                    if (flush_data_only) then
+                    if (flush_data_only_local) then
 #ifdef _DEBUG_MEM_
                         print *, "In buffer flush mode!"
 #endif

--- a/ncdiag/ncdw_metadata.F90
+++ b/ncdiag/ncdw_metadata.F90
@@ -482,8 +482,8 @@ module ncdw_metadata
             
 #ifdef ENABLE_ACTION_MSGS            
             if (nclayer_enable_action) then
-                if (flush_data_only_local) then
-                    write(action_str, "(A, L, A)") "nc_diag_metadata_write_data(flush_data_only = ", flush_data_only_local, ")"
+                if (present(flush_data_only)) then
+                    write(action_str, "(A, L, A)") "nc_diag_metadata_write_data(flush_data_only = ", flush_data_only, ")"
                 else
                     write(action_str, "(A)") "nc_diag_metadata_write_data(flush_data_only = (not specified))"
                 end if


### PR DESCRIPTION
spack-stack issue [#1931](https://github.com/JCSDA/spack-stack/issues/1931) documents the failure of spack-stack/2.0.0 gsi-ncdiag/1.1.2 when included in an ifx build of GSI on Ursa.  Debugging traced the failure to the use of optional logical subroutine arguments in `if` constructs. 

This PR sets a local logical variable based on the availability of an option logical argument passed into various subroutines.  The local logical variable is then used in the subroutine.  The ifx build of GSI-ncdiag and GSI successfully runs to completion on Ursa with the source code changes in this PR.

Resolves #10